### PR TITLE
Fix syntax error in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,6 @@
     "license": "proprietary",
     "type": "magento-module",
     "require": {
-        "magento-hackathon/magento-composer-installer": ">=2",
+        "magento-hackathon/magento-composer-installer": ">=2"
     }
 }


### PR DESCRIPTION
There was a trailing `,` in the composer.json file making composer's parser failing during installation.
